### PR TITLE
fix: wire in-app notifications for incident/task event flow

### DIFF
--- a/backend/src/api/routes/incidents.py
+++ b/backend/src/api/routes/incidents.py
@@ -85,13 +85,16 @@ def assign_incident(
     current_user: Annotated[User, Depends(get_current_user)],
     incident_repo: Annotated[IncidentRepository, Depends(get_incident_repository)],
     user_repo: Annotated[UserRepository, Depends(get_user_repository)],
+    event_bus: Annotated[EventBus, Depends(get_event_bus)],
 ):
+
     """
     Assign incident to a user.
 
     Requires SUPERVISOR or ADMIN role (should be enforced by route decorator).
     """
-    use_case = AssignIncidentUseCase(incident_repo, user_repo)
+    use_case = AssignIncidentUseCase(incident_repo, user_repo, event_bus=event_bus)
+
     try:
         return use_case.execute(
             incident_id=incident_id,
@@ -108,7 +111,9 @@ def change_incident_status(
     status_update: IncidentStatusUpdate,
     current_user: Annotated[User, Depends(get_current_user)],
     incident_repo: Annotated[IncidentRepository, Depends(get_incident_repository)],
+    event_bus: Annotated[EventBus, Depends(get_event_bus)],
 ):
+
     """
     Change incident status.
 
@@ -116,7 +121,8 @@ def change_incident_status(
     - OPERATOR can change their own incidents (implemented in future)
     - SUPERVISOR/ADMIN can change any incident
     """
-    use_case = ChangeIncidentStatusUseCase(incident_repo)
+    use_case = ChangeIncidentStatusUseCase(incident_repo, event_bus=event_bus)
+
     try:
         return use_case.execute(
             incident_id=incident_id,

--- a/backend/src/api/routes/tasks.py
+++ b/backend/src/api/routes/tasks.py
@@ -17,12 +17,15 @@ from ...domain.repositories.incident_repository import IncidentRepository
 from ...domain.repositories.user_repository import UserRepository
 from ...domain.entities.user import User
 from ...domain.exceptions import EntityNotFoundError, PermissionDeniedError
+from ...infrastructure.events.event_bus import EventBus
 from ..dependencies import (
     get_task_repository,
     get_incident_repository,
     get_user_repository,
     get_current_user,
+    get_event_bus,
 )
+
 
 router = APIRouter()
 
@@ -50,14 +53,17 @@ def create_task(
     task_repo: Annotated[TaskRepository, Depends(get_task_repository)],
     incident_repo: Annotated[IncidentRepository, Depends(get_incident_repository)],
     user_repo: Annotated[UserRepository, Depends(get_user_repository)],
+    event_bus: Annotated[EventBus, Depends(get_event_bus)],
 ):
+
     """
     Create a new task linked to an incident.
 
     Any authenticated user can create tasks (subject to incident access).
     Operators can only create tasks for incidents they own or are assigned to.
     """
-    use_case = CreateTaskUseCase(task_repo, incident_repo, user_repo)
+    use_case = CreateTaskUseCase(task_repo, incident_repo, user_repo, event_bus=event_bus)
+
     try:
         return use_case.execute(data, creator_id=current_user.id)
     except EntityNotFoundError as e:
@@ -75,14 +81,17 @@ def update_task(
     current_user: Annotated[User, Depends(get_current_user)],
     task_repo: Annotated[TaskRepository, Depends(get_task_repository)],
     user_repo: Annotated[UserRepository, Depends(get_user_repository)],
+    event_bus: Annotated[EventBus, Depends(get_event_bus)],
 ):
+
     """
     Update a task (status, assignment, title, description).
 
     - Assigned users can update status and their own tasks
     - ADMIN/SUPERVISOR can update any task and reassign
     """
-    use_case = UpdateTaskUseCase(task_repo, user_repo)
+    use_case = UpdateTaskUseCase(task_repo, user_repo, event_bus=event_bus)
+
     try:
         return use_case.execute(task_id, updates, user_id=current_user.id)
     except EntityNotFoundError as e:
@@ -100,7 +109,9 @@ def update_task_status(
     current_user: Annotated[User, Depends(get_current_user)],
     task_repo: Annotated[TaskRepository, Depends(get_task_repository)],
     user_repo: Annotated[UserRepository, Depends(get_user_repository)],
+    event_bus: Annotated[EventBus, Depends(get_event_bus)],
 ):
+
     """
     Update task status.
 
@@ -108,7 +119,8 @@ def update_task_status(
     """
     # Reuse update_task with only status field
     updates = TaskUpdate(status=status_update.status)
-    use_case = UpdateTaskUseCase(task_repo, user_repo)
+    use_case = UpdateTaskUseCase(task_repo, user_repo, event_bus=event_bus)
+
     try:
         return use_case.execute(task_id, updates, user_id=current_user.id)
     except EntityNotFoundError as e:

--- a/backend/src/application/use_cases/incidents/assign_incident.py
+++ b/backend/src/application/use_cases/incidents/assign_incident.py
@@ -5,9 +5,13 @@ from datetime import datetime
 from ...dtos.incident_dto import IncidentAssign
 from ....domain.entities.incident import Incident
 from ....domain.enums.incident_status import IncidentStatus
+from ....domain.enums.event_type import EventType
+from ....domain.patterns.observer import DomainEvent
 from ....domain.repositories.incident_repository import IncidentRepository
 from ....domain.repositories.user_repository import UserRepository
 from ....domain.exceptions import EntityNotFoundError, PermissionDeniedError
+from ....infrastructure.events.event_bus import EventBus
+
 
 
 class AssignIncidentUseCase:
@@ -17,7 +21,9 @@ class AssignIncidentUseCase:
         self,
         incident_repository: IncidentRepository,
         user_repository: UserRepository,
+        event_bus: EventBus | None = None,
     ):
+
         """
         Initialize use case.
 
@@ -27,6 +33,8 @@ class AssignIncidentUseCase:
         """
         self.incident_repository = incident_repository
         self.user_repository = user_repository
+        self.event_bus = event_bus
+
 
     def execute(self, incident_id: int, assigned_to_id: int, assigner_id: int) -> Incident:
         """
@@ -64,4 +72,19 @@ class AssignIncidentUseCase:
         incident.updated_at = datetime.now()
 
         saved = self.incident_repository.save(incident)
+
+        if self.event_bus is not None and saved.id is not None:
+            self.event_bus.publish(
+                DomainEvent(
+                    event_type=EventType.INCIDENT_ASSIGNED,
+                    data={
+                        "incident_id": saved.id,
+                        "assigned_to_id": assigned_to_id,
+                        "assigner_id": assigner_id,
+                    },
+                    timestamp=datetime.now(),
+                )
+            )
+
         return saved
+

--- a/backend/src/application/use_cases/incidents/change_incident_status.py
+++ b/backend/src/application/use_cases/incidents/change_incident_status.py
@@ -5,15 +5,20 @@ from datetime import datetime
 from ...dtos.incident_dto import IncidentStatusUpdate
 from ....domain.entities.incident import Incident
 from ....domain.enums.incident_status import IncidentStatus
+from ....domain.enums.event_type import EventType
+from ....domain.patterns.observer import DomainEvent
 from ....domain.patterns.state import IncidentStateMachine
 from ....domain.repositories.incident_repository import IncidentRepository
 from ....domain.exceptions import InvalidStateTransitionError
+from ....infrastructure.events.event_bus import EventBus
+
 
 
 class ChangeIncidentStatusUseCase:
     """Use case for changing incident status using State pattern."""
 
-    def __init__(self, incident_repository: IncidentRepository):
+    def __init__(self, incident_repository: IncidentRepository, event_bus: EventBus | None = None):
+
         """
         Initialize use case.
 
@@ -22,6 +27,8 @@ class ChangeIncidentStatusUseCase:
         """
         self.incident_repository = incident_repository
         self.state_machine = IncidentStateMachine()
+        self.event_bus = event_bus
+
 
     def execute(self, incident_id: int, new_status: IncidentStatus, user_id: int) -> Incident:
         """
@@ -51,8 +58,25 @@ class ChangeIncidentStatusUseCase:
             )
 
         # Update status
+        previous_status = incident.status
         incident.status = new_status
         incident.updated_at = datetime.now()
 
         saved = self.incident_repository.save(incident)
+
+        if self.event_bus is not None and saved.id is not None:
+            self.event_bus.publish(
+                DomainEvent(
+                    event_type=EventType.INCIDENT_STATUS_CHANGED,
+                    data={
+                        "incident_id": saved.id,
+                        "previous_status": previous_status.value,
+                        "new_status": new_status.value,
+                        "changer_id": user_id,
+                    },
+                    timestamp=datetime.now(),
+                )
+            )
+
         return saved
+

--- a/backend/src/application/use_cases/tasks/create_task.py
+++ b/backend/src/application/use_cases/tasks/create_task.py
@@ -5,11 +5,15 @@ from datetime import datetime, timezone
 from ...dtos.task_dto import TaskCreate
 from ....domain.entities.task import Task
 from ....domain.enums.task_status import TaskStatus
+from ....domain.enums.event_type import EventType
+from ....domain.patterns.observer import DomainEvent
 from ....domain.repositories.task_repository import TaskRepository
 from ....domain.repositories.incident_repository import IncidentRepository
 from ....domain.repositories.user_repository import UserRepository
 from ....domain.patterns.factory import EntityFactory
 from ....domain.exceptions import EntityNotFoundError, PermissionDeniedError
+from ....infrastructure.events.event_bus import EventBus
+
 
 
 class CreateTaskUseCase:
@@ -21,7 +25,9 @@ class CreateTaskUseCase:
         incident_repository: IncidentRepository,
         user_repository: UserRepository,
         factory: EntityFactory | None = None,
+        event_bus: EventBus | None = None,
     ):
+
         """
         Initialize use case.
 
@@ -35,6 +41,8 @@ class CreateTaskUseCase:
         self.incident_repository = incident_repository
         self.user_repository = user_repository
         self.factory = factory or EntityFactory()
+        self.event_bus = event_bus
+
 
     def execute(self, data: TaskCreate, creator_id: int) -> Task:
         """
@@ -80,4 +88,19 @@ class CreateTaskUseCase:
 
         # Persist
         saved = self.task_repository.save(task)
+
+        if self.event_bus is not None and saved.id is not None:
+            self.event_bus.publish(
+                DomainEvent(
+                    event_type=EventType.TASK_CREATED,
+                    data={
+                        "task_id": saved.id,
+                        "incident_id": saved.incident_id,
+                        "creator_id": creator_id,
+                    },
+                    timestamp=datetime.now(timezone.utc),
+                )
+            )
+
         return saved
+

--- a/backend/src/application/use_cases/tasks/update_task.py
+++ b/backend/src/application/use_cases/tasks/update_task.py
@@ -7,7 +7,12 @@ from ....domain.entities.task import Task
 from ....domain.repositories.task_repository import TaskRepository
 from ....domain.repositories.user_repository import UserRepository
 from ....domain.enums.role import Role
+from ....domain.enums.task_status import TaskStatus
+from ....domain.enums.event_type import EventType
+from ....domain.patterns.observer import DomainEvent
 from ....domain.exceptions import EntityNotFoundError, PermissionDeniedError
+from ....infrastructure.events.event_bus import EventBus
+
 
 
 class UpdateTaskUseCase:
@@ -17,7 +22,9 @@ class UpdateTaskUseCase:
         self,
         task_repository: TaskRepository,
         user_repository: UserRepository,
+        event_bus: EventBus | None = None,
     ):
+
         """
         Initialize use case.
 
@@ -27,6 +34,8 @@ class UpdateTaskUseCase:
         """
         self.task_repository = task_repository
         self.user_repository = user_repository
+        self.event_bus = event_bus
+
 
     def execute(self, task_id: int, updates: TaskUpdate, user_id: int) -> Task:
         """
@@ -60,8 +69,13 @@ class UpdateTaskUseCase:
         if not (is_assigned or is_privileged):
             raise PermissionDeniedError("Cannot update this task")
 
+        # Track previous values for event publishing
+        previous_status = task.status
+        previous_assigned_to = task.assigned_to
+
         # Apply updates
         if updates.title is not None:
+
             task.title = updates.title.strip()
         if updates.description is not None:
             task.description = updates.description.strip()
@@ -81,4 +95,34 @@ class UpdateTaskUseCase:
 
         # Persist
         saved = self.task_repository.save(task)
+
+        if self.event_bus is not None and saved.id is not None:
+            if saved.assigned_to is not None and saved.assigned_to != previous_assigned_to:
+                self.event_bus.publish(
+                    DomainEvent(
+                        event_type=EventType.TASK_ASSIGNED,
+                        data={
+                            "task_id": saved.id,
+                            "incident_id": saved.incident_id,
+                            "assigned_to_id": saved.assigned_to,
+                            "assigner_id": user_id,
+                        },
+                        timestamp=datetime.now(timezone.utc),
+                    )
+                )
+
+            if previous_status != TaskStatus.DONE and saved.status == TaskStatus.DONE:
+                self.event_bus.publish(
+                    DomainEvent(
+                        event_type=EventType.TASK_DONE,
+                        data={
+                            "task_id": saved.id,
+                            "incident_id": saved.incident_id,
+                            "completed_by": user_id,
+                        },
+                        timestamp=datetime.now(timezone.utc),
+                    )
+                )
+
         return saved
+

--- a/backend/src/domain/patterns/concrete_observers.py
+++ b/backend/src/domain/patterns/concrete_observers.py
@@ -13,7 +13,13 @@ from ...domain.repositories.incident_repository import IncidentRepository
 from ...domain.entities.notification import Notification
 from ...domain.enums.notification_channel import NotificationChannel
 from ...domain.enums.notification_status import NotificationStatus
-from ...domain.patterns.template_method import NotificationBuilder
+from ...domain.patterns.template_method import (
+    NotificationBuilder,
+    IncidentCreatedNotificationBuilder,
+    IncidentAssignedNotificationBuilder,
+    IncidentStatusChangedNotificationBuilder,
+)
+
 from ...infrastructure.notifications.email_sender import EmailNotificationCommand
 from ...infrastructure.notifications.slack_sender import SlackNotificationCommand
 import logging


### PR DESCRIPTION
## Summary
- Wire event publishing from incident assignment and status change use cases so in-app notifications are generated beyond incident creation.
- Wire event publishing from task creation/update use cases for task created, assigned, and done transitions.
- Fix notification observer imports for template builders that were causing runtime `NameError` and preventing notification persistence.

## Validation
- Ran API smoke flow with seeded users (login -> create/assign/status incident -> check notifications).
- Confirmed `/notifications` returns created records for admin and supervisor after incident events.